### PR TITLE
Fixing initialization of Feature Model

### DIFF
--- a/famapy/metamodels/fm_metamodel/models/feature_model.py
+++ b/famapy/metamodels/fm_metamodel/models/feature_model.py
@@ -86,9 +86,9 @@ class FeatureModel(VariabilityModel):
     def __init__(
         self,
         root: Feature,
-        constraint: list['Constraint'] = list(),
-        features: list['Feature'] = list(),
-        relations: list['Relation'] = list()
+        constraint: list['Constraint'] = [],
+        features: list['Feature'] = [],
+        relations: list['Relation'] = []
     ):
         self.root = root
         self.ctcs = constraint  # implementar CTC con AST

--- a/famapy/metamodels/fm_metamodel/models/feature_model.py
+++ b/famapy/metamodels/fm_metamodel/models/feature_model.py
@@ -86,10 +86,16 @@ class FeatureModel(VariabilityModel):
     def __init__(
         self,
         root: Feature,
-        constraint: list['Constraint'] = [],
-        features: list['Feature'] = [],
-        relations: list['Relation'] = []
+        constraint: list['Constraint'] = None,
+        features: list['Feature'] = None,
+        relations: list['Relation'] = None
     ):
+        if constraint is None:
+            constraint = []
+        if features is None:
+            features = []
+        if relations is None:
+            relations = []
         self.root = root
         self.ctcs = constraint  # implementar CTC con AST
         self.features = features

--- a/famapy/metamodels/fm_metamodel/models/feature_model.py
+++ b/famapy/metamodels/fm_metamodel/models/feature_model.py
@@ -1,5 +1,4 @@
-from famapy.core.models import AST
-from famapy.core.models import VariabilityModel
+from famapy.core.models import AST, VariabilityModel
 
 
 class Relation:
@@ -87,9 +86,9 @@ class FeatureModel(VariabilityModel):
     def __init__(
         self,
         root: Feature,
-        constraint: list['Constraint'] = list,
-        features: list['Feature'] = list,
-        relations: list['Relation'] = list
+        constraint: list['Constraint'] = list(),
+        features: list['Feature'] = list(),
+        relations: list['Relation'] = list()
     ):
         self.root = root
         self.ctcs = constraint  # implementar CTC con AST


### PR DESCRIPTION
Features, realtions and constraints must be initializeds as empty list not as a type.  First it is initialized as none and then as an empty list to follow good practices.