### PR TITLE
Fix errors in FeatureIDE parser and FM metamodel + new operation for FM

### DIFF
--- a/famapy/metamodels/fm_metamodel/models/__init__.py
+++ b/famapy/metamodels/fm_metamodel/models/__init__.py
@@ -4,5 +4,6 @@ from .feature_model import (
     FeatureModel,
     Relation,
 )
+from .fm_configuration import FMConfiguration
 
-__all__ = ["FeatureModel", "Feature", "Relation", "Constraint"]
+__all__ = ["FeatureModel", "Feature", "Relation", "Constraint", "FMConfiguration"]

--- a/famapy/metamodels/fm_metamodel/models/feature_model.py
+++ b/famapy/metamodels/fm_metamodel/models/feature_model.py
@@ -169,11 +169,6 @@ class FeatureModel(VariabilityModel):
     def get_constraints(self) -> list['Constraint']:
         return self.ctcs
 
-    def get_feature_by_name(self, feature_name: str) -> 'Feature':
-        if feature_name not in self.features_by_name.keys():
-            raise Exception(f'Not feature with name: {feature_name}')
-        return self.features_by_name[feature_name]
-
     def __str__(self) -> str:
         if self.root.is_empty():
             return '(empty feature model)'

--- a/famapy/metamodels/fm_metamodel/models/feature_model.py
+++ b/famapy/metamodels/fm_metamodel/models/feature_model.py
@@ -108,6 +108,9 @@ class Feature:
     def is_group(self) -> bool:
         return self.is_or_group() or self.is_alternative_group()
 
+    def is_leaf(self) -> bool:
+        return len(self.get_relations()) == 0
+
     def __str__(self) -> str:
         return self.name
 

--- a/famapy/metamodels/fm_metamodel/operations/__init__.py
+++ b/famapy/metamodels/fm_metamodel/operations/__init__.py
@@ -4,10 +4,12 @@ from .fm_leaf_features import FMLeafFeatures, get_leaf_features
 from .fm_average_branching_factor import FMAverageBranchingFactor, average_branching_factor
 from .fm_feature_ancestors import FMFeatureAncestors, get_feature_ancestors
 from .fm_max_depth_tree import FMMaxDepthTree, max_depth_tree
+from .fm_number_of_configurations import FMNumberOfConfigurations, count_configurations
 
 __all__ = ['FMCoreFeatures', 'get_core_features',
            'FMCountLeafs', 'count_leaf_features',
            'FMLeafFeatures', 'get_leaf_features', 
            'FMAverageBranchingFactor', 'average_branching_factor',
            'FMFeatureAncestors', 'get_feature_ancestors',
-           'FMMaxDepthTree', 'max_depth_tree']
+           'FMMaxDepthTree', 'max_depth_tree',
+           'FMNumberOfConfigurations', 'count_configurations']

--- a/famapy/metamodels/fm_metamodel/operations/fm_number_of_configurations.py
+++ b/famapy/metamodels/fm_metamodel/operations/fm_number_of_configurations.py
@@ -1,0 +1,49 @@
+from typing import Optional
+import math
+
+from famapy.core.operations import NumberOfConfigurations
+
+from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature, FMConfiguration
+
+
+class FMNumberOfConfigurations(NumberOfConfigurations):
+    """It computes the number of configurations of the feature model.
+
+    It only uses the structure of the feature model, 
+    without taking into account the cross-tree constraints,
+    and thus, the number is an upper limit of the real number of configurations.
+    """
+    
+    def __init__(self, partial_configuration: Optional[FMConfiguration] = None) -> None:
+        self.result = 0
+        self.feature_model = None
+        self.partial_configuration = partial_configuration
+    
+    def execute(self, feature_model: FeatureModel) -> 'FMNumberOfConfigurations':
+        self.feature_model = feature_model
+        self.result = self.get_number_of_configurations(self.partial_configuration)
+        return self
+
+    def get_result(self) -> int:
+        return self.result
+
+    def get_number_of_configurations(self, partial_configuration: Optional[FMConfiguration] = None) -> int:
+        return count_configurations(self.feature_model, partial_configuration)
+
+def count_configurations(feature_model: FeatureModel, partial_configuration: Optional[FMConfiguration] = None) -> int:
+    return count_configurations_rec(feature_model.root)
+
+def count_configurations_rec(feature: Feature) -> int:
+    if feature.is_leaf():
+        return 1
+    counts = []
+    for relation in feature.get_relations():
+        if relation.is_mandatory():
+            counts.append(count_configurations_rec(relation.children[0]))
+        elif relation.is_optional():
+            counts.append(count_configurations_rec(relation.children[0]) + 1)
+        elif relation.is_alternative():
+            counts.append(sum((count_configurations_rec(f) for f in relation.children)))
+        elif relation.is_or():
+            counts.append(math.prod([count_configurations_rec(f) + 1 for f in relation.children]) - 1)
+    return math.prod(counts)

--- a/famapy/metamodels/fm_metamodel/operations/fm_number_of_configurations.py
+++ b/famapy/metamodels/fm_metamodel/operations/fm_number_of_configurations.py
@@ -1,37 +1,37 @@
-from typing import Optional
 import math
 
-from famapy.core.operations import NumberOfConfigurations
+from famapy.core.operations import ProductsNumber
 
-from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature, FMConfiguration
+from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature
 
 
-class FMNumberOfConfigurations(NumberOfConfigurations):
+class FMNumberOfConfigurations(ProductsNumber):
     """It computes the number of configurations of the feature model.
 
     It only uses the structure of the feature model, 
     without taking into account the cross-tree constraints,
     and thus, the number is an upper limit of the real number of configurations.
     """
-    
-    def __init__(self, partial_configuration: Optional[FMConfiguration] = None) -> None:
+
+    def __init__(self) -> None:
         self.result = 0
         self.feature_model = None
-        self.partial_configuration = partial_configuration
-    
-    def execute(self, feature_model: FeatureModel) -> 'FMNumberOfConfigurations':
-        self.feature_model = feature_model
-        self.result = self.get_number_of_configurations(self.partial_configuration)
+
+    def execute(self, model: FeatureModel) -> 'FMNumberOfConfigurations':
+        self.feature_model = model
+        self.result = self.get_number_of_configurations()
         return self
 
     def get_result(self) -> int:
         return self.result
 
-    def get_number_of_configurations(self, partial_configuration: Optional[FMConfiguration] = None) -> int:
-        return count_configurations(self.feature_model, partial_configuration)
+    def get_products_number(self) -> int:
+        return count_configurations(self.feature_model)
 
-def count_configurations(feature_model: FeatureModel, partial_configuration: Optional[FMConfiguration] = None) -> int:
+
+def count_configurations(feature_model: FeatureModel) -> int:
     return count_configurations_rec(feature_model.root)
+
 
 def count_configurations_rec(feature: Feature) -> int:
     if feature.is_leaf():
@@ -45,5 +45,6 @@ def count_configurations_rec(feature: Feature) -> int:
         elif relation.is_alternative():
             counts.append(sum((count_configurations_rec(f) for f in relation.children)))
         elif relation.is_or():
-            counts.append(math.prod([count_configurations_rec(f) + 1 for f in relation.children]) - 1)
+            children_counts = [count_configurations_rec(f) + 1 for f in relation.children]
+            counts.append(math.prod(children_counts) - 1)
     return math.prod(counts)


### PR DESCRIPTION
Changes:

- I've found an error in the FeatureIDE parser so that the relations of the root feature were not correctly stored. Fix in 5780fc1.
- I've also simplified the parser so that the list of features and relations do not need to be tracked, but in the future it may be needed for efficiency buidling the feature model, so take into account this change in b8ab2b1 to revert if neccesary.
- The last refactor of the FM metamodel gets the `get_feature_by_name` useless. Removed in 07b811d.
- Add a new `is_leaf` method for features in `Feature` class.
- Add new operation to calculate the number of configurations using only the feature model structure without relying on SAT solver or BDD. In this case, cross-tree constraints are not considered so the resulting number if an upper limit, but it can be calculated for large-scale feature model like the Linux one. We use the recursive algorithm from [Apel et al. 2013](https://dl.acm.org/doi/10.5555/2541773) (p. 251, Sec 10.16). It is pending to improve this method using the [Fernandez-Amoros et al. 2009](https://dl.acm.org/citation.cfm?id=1753242) algorithm that also considers certain kinds of cross-tree constraints, but it is more sophisticated to be implemented.

