### PR TITLE
Changes regarding attribute support on uvl transformation and writer

### DIFF
--- a/famapy/metamodels/fm_metamodel/models/feature_model.py
+++ b/famapy/metamodels/fm_metamodel/models/feature_model.py
@@ -303,8 +303,12 @@ class Attribute:
 
     def __str__(self) -> str:
 
-        result = self.parent.name + "." + self.name + ": " + \
-            str(self.domain) + "," + str(self.default_value) + \
-            "," + str(self.null_value)
+        result = "[" + self.parent.name + "." + self.name + "]"
+        if self.domain is not None:
+            result = result + "Domain: " + str(self.domain)
+        if self.default_value is not None:
+            result = result + "Default value: " + str(self.default_value)
+        if self.null_value is not None:
+            result = result + "Null value: " + str(self.null_value)
 
         return result

--- a/famapy/metamodels/fm_metamodel/transformations/uvl_transformation.py
+++ b/famapy/metamodels/fm_metamodel/transformations/uvl_transformation.py
@@ -4,7 +4,6 @@ from typing import Any, Optional
 from uvlparser import get_tree, UVLParser
 from famapy.core.transformations import TextToModel
 from famapy.core.models.ast import AST
-import uvlparser
 from famapy.metamodels.fm_metamodel.models.feature_model import (
     Constraint,
     Feature,
@@ -87,7 +86,8 @@ class UVLTransformation(TextToModel):
         else:
             cls.__add_relation_min_max(parent, children, relation_text)
 
-    def add_attributes(self, feature_node: UVLParser.FeaturesContext, feature: Feature):
+    @classmethod
+    def add_attributes(cls, feature_node: UVLParser.FeaturesContext, feature: Feature) -> None:
 
         attributes_node = feature_node.feature_spec().attributes()
 

--- a/famapy/metamodels/fm_metamodel/transformations/uvl_transformation.py
+++ b/famapy/metamodels/fm_metamodel/transformations/uvl_transformation.py
@@ -34,6 +34,7 @@ class UVLTransformation(TextToModel):
         parse_tree_root_feature = self.find_root_feature()
         root_feature_text = self.get_feature_text(parse_tree_root_feature)
         root_feature = Feature(root_feature_text, [])
+        self.add_attributes(parse_tree_root_feature, root_feature)
         # Feature model created with root feature
         self.model = FeatureModel(root_feature, [])
         # Recursively read the ParseTree root feature subnode to find all features and relations

--- a/famapy/metamodels/fm_metamodel/transformations/uvl_writter.py
+++ b/famapy/metamodels/fm_metamodel/transformations/uvl_writter.py
@@ -38,7 +38,8 @@ class UVLWriter(ModelToText):
                 result = self.read_features(feature_node, result, tab_count)
         return result
 
-    def read_attributes(self, feature: Feature) -> str:
+    @classmethod
+    def read_attributes(cls, feature: Feature) -> str:
         attributes = feature.get_attributes()
         result = ""
 

--- a/famapy/metamodels/fm_metamodel/transformations/uvl_writter.py
+++ b/famapy/metamodels/fm_metamodel/transformations/uvl_writter.py
@@ -28,13 +28,32 @@ class UVLWriter(ModelToText):
 
     def read_features(self, feature: Feature, result: str, tab_count: int) -> str:
         tab_count = tab_count + 1
-        result = result + "\n" + tab_count * "\t" + feature.name
+        result = result + "\n" + tab_count * "\t" + \
+            feature.name + self.read_attributes(feature)
         tab_count = tab_count + 1
         for relation in feature.relations:
             relation_name = self.serialize_relation(relation)
             result = result + "\n" + tab_count * "\t" + relation_name
             for feature_node in relation.children:
                 result = self.read_features(feature_node, result, tab_count)
+        return result
+
+    def read_attributes(self, feature: Feature) -> str:
+        attributes = feature.get_attributes()
+        result = ""
+
+        if len(attributes) > 0:
+            result = "{"
+            first = True
+            for attribute in attributes:
+                if not first:
+                    result += ", "
+                result += attribute.name
+                if attribute.default_value is not None:
+                    result += ' "' + attribute.default_value + '"'
+                first = False
+            result += "}"
+
         return result
 
     @staticmethod


### PR DESCRIPTION
uvl_transformation and uvl_writer updated so they can parse and serialize attributes respectively.

fm_metamodel attributes' __str__ made more descriptive while also skipping class attributes set to None, as uvl does not currently support value domains or null values.

Despite this issue comming from an external project, uvl_transformation no longer triggers the parser warnings it used to do.