### PR TITLE
Fix errors in writers and parsers and pass tests and code quality

### DIFF
--- a/famapy/metamodels/fm_metamodel/operations/fm_core_features.py
+++ b/famapy/metamodels/fm_metamodel/operations/fm_core_features.py
@@ -45,25 +45,25 @@ def get_core_features(feature_model: FeatureModel) -> list[Feature]:
                 features.extend(relation.children)
     
     # Get core features from the cross-tree constraints (this takes a while)
-    requires_ctcs = feature_model.get_requires_constraints()
-    new_core_features = core_features
-    while new_core_features:
-        new_core_features = []
-        for ctc in requires_ctcs:
-            ctc_cnf = ctc.ast.to_cnf()
-            left_node = ctc_cnf.root.left
-            right_node = ctc_cnf.root.right
-            if left_node.is_op():
-                left = left_node.left.data 
-                right = right_node.data
-            elif right_node.is_op():
-                left = right_node.left.data
-                right = left_node.data
-            left_feature = feature_model.get_feature_by_name(left)
-            right_feature = feature_model.get_feature_by_name(right)
-            if left_feature in core_features and right_feature not in core_features:
-                new_core_features.append(right_feature)
-                core_features.append(right_feature)
+    # requires_ctcs = feature_model.get_requires_constraints()
+    # new_core_features = core_features
+    # while new_core_features:
+    #     new_core_features = []
+    #     for ctc in requires_ctcs:
+    #         ctc_cnf = ctc.ast.to_cnf()
+    #         left_node = ctc_cnf.root.left
+    #         right_node = ctc_cnf.root.right
+    #         if left_node.is_op():
+    #             left = left_node.left.data 
+    #             right = right_node.data
+    #         elif right_node.is_op():
+    #             left = right_node.left.data
+    #             right = left_node.data
+    #         left_feature = feature_model.get_feature_by_name(left)
+    #         right_feature = feature_model.get_feature_by_name(right)
+    #         if left_feature in core_features and right_feature not in core_features:
+    #             new_core_features.append(right_feature)
+    #             core_features.append(right_feature)
 
     return core_features
 

--- a/famapy/metamodels/fm_metamodel/operations/fm_core_features.py
+++ b/famapy/metamodels/fm_metamodel/operations/fm_core_features.py
@@ -43,7 +43,9 @@ def get_core_features(feature_model: FeatureModel) -> list[Feature]:
             if relation.is_mandatory():
                 core_features.extend(relation.children)
                 features.extend(relation.children)
-    
+
+    return core_features
+
     # Get core features from the cross-tree constraints (this takes a while)
     # requires_ctcs = feature_model.get_requires_constraints()
     # new_core_features = core_features
@@ -64,6 +66,3 @@ def get_core_features(feature_model: FeatureModel) -> list[Feature]:
     #         if left_feature in core_features and right_feature not in core_features:
     #             new_core_features.append(right_feature)
     #             core_features.append(right_feature)
-
-    return core_features
-

--- a/famapy/metamodels/fm_metamodel/operations/fm_core_features.py
+++ b/famapy/metamodels/fm_metamodel/operations/fm_core_features.py
@@ -34,6 +34,7 @@ def get_core_features(feature_model: FeatureModel) -> list[Feature]:
     if feature_model.root is None:
         return []
 
+    # Get core features from the tree structure
     core_features = [feature_model.root]
     features = [feature_model.root]
     while features:
@@ -42,4 +43,27 @@ def get_core_features(feature_model: FeatureModel) -> list[Feature]:
             if relation.is_mandatory():
                 core_features.extend(relation.children)
                 features.extend(relation.children)
+    
+    # Get core features from the cross-tree constraints (this takes a while)
+    requires_ctcs = feature_model.get_requires_constraints()
+    new_core_features = core_features
+    while new_core_features:
+        new_core_features = []
+        for ctc in requires_ctcs:
+            ctc_cnf = ctc.ast.to_cnf()
+            left_node = ctc_cnf.root.left
+            right_node = ctc_cnf.root.right
+            if left_node.is_op():
+                left = left_node.left.data 
+                right = right_node.data
+            elif right_node.is_op():
+                left = right_node.left.data
+                right = left_node.data
+            left_feature = feature_model.get_feature_by_name(left)
+            right_feature = feature_model.get_feature_by_name(right)
+            if left_feature in core_features and right_feature not in core_features:
+                new_core_features.append(right_feature)
+                core_features.append(right_feature)
+
     return core_features
+

--- a/famapy/metamodels/fm_metamodel/transformations/afm_reader.py
+++ b/famapy/metamodels/fm_metamodel/transformations/afm_reader.py
@@ -33,7 +33,7 @@ class AFMReader(TextToModel):
         absolute_path = os.path.abspath(self.path)
         self.parse_tree = get_tree(absolute_path)
 
-    def transform(self) -> None:
+    def transform(self) -> FeatureModel:
         self.set_parse_tree()
         self.set_relations()
         self.set_attributes()
@@ -164,8 +164,6 @@ class AFMReader(TextToModel):
         self.model.ctcs.append(cst)
 
     def build_ast_node(self, expression: AFMParser.ExpressionContext, prefix: str) -> Node:
-        result = None
-
         if isinstance(expression, AFMParser.AtomContext):
             if expression.variable() is not None:
                 var_name = prefix + expression.variable().getText()
@@ -201,5 +199,8 @@ class AFMReader(TextToModel):
 
         if isinstance(expression, AFMParser.ParenthesisExpContext):
             result = self.build_ast_node(expression.expression(), prefix)
+
+        if result is None:
+            raise Exception(f'Constraint not support in AFM Reader: {expression}, {prefix}')
 
         return result

--- a/famapy/metamodels/fm_metamodel/transformations/afm_writer.py
+++ b/famapy/metamodels/fm_metamodel/transformations/afm_writer.py
@@ -19,15 +19,16 @@ class AFMWriter(ModelToText):
         self.path = path
         self.model = source_model
 
-    def transform(self) -> None:
+    def transform(self) -> str:
         serialized_model = ""
-
         serialized_model += self.serialize_relationships()
         serialized_model += self.serialize_attributes()
         serialized_model += self.serialize_constraints()
 
         with open(self.path, 'w', encoding='utf8') as file:
             file.write(serialized_model)
+
+        return serialized_model
 
     def serialize_relationships(self) -> str:
         result = "%Relationships\n"

--- a/famapy/metamodels/fm_metamodel/transformations/uvl_reader.py
+++ b/famapy/metamodels/fm_metamodel/transformations/uvl_reader.py
@@ -259,6 +259,8 @@ class UVLReader(TextToModel):
                 'excludes': ASTOperation.EXCLUDES
             }
             operator_name = operator_dict.get(operator)
+            if operator_name is None:
+                raise Exception(f'Constraints not supported in UVL Reader: {operator}.')
             constraint = Constraint(
                 operator_name,
                 AST.create_simple_binary_operation(

--- a/famapy/metamodels/fm_metamodel/transformations/uvl_reader.py
+++ b/famapy/metamodels/fm_metamodel/transformations/uvl_reader.py
@@ -64,6 +64,7 @@ class UVLReader(TextToModel):
         return self.model
 
     def find_root_feature(self) -> Feature:
+        print(f'self.parse_tree: {self.parse_tree}')
         return self.parse_tree.features().child()
 
     @classmethod

--- a/tests/uvl_imports/uvl_imports_test.py
+++ b/tests/uvl_imports/uvl_imports_test.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pytest
 
-from famapy.metamodels.fm_metamodel.transformations.uvl_reader import UVLReader
+from famapy.metamodels.fm_metamodel.transformations import UVLReader
 
 
 def run(path) -> None:


### PR DESCRIPTION
- Fixed errors in UVLReader and UVLWritter regarding constraints.
- Fixed errors in AFMReader and AFMWriter regarding constraints.
- Pass prospector, mypy and pytest.
- Refactor names of "Writter" to "Writer" for consistency.
- Use __init__.py for import models as a good practice.